### PR TITLE
Fix error on .git directory

### DIFF
--- a/prompt_lean_setup
+++ b/prompt_lean_setup
@@ -45,7 +45,7 @@ prompt_lean_git_dirty() {
     command git rev-parse --is-inside-work-tree &>/dev/null || return
     # check if it's dirty
     local umode="-uno" #|| local umode="-unormal"
-    command test -n "$(git status --porcelain --ignore-submodules ${umode})"
+    command test -n "$(git status --porcelain --ignore-submodules ${umode} 2>/dev/null)"
 
     (($? == 0)) && echo ' +'
 }


### PR DESCRIPTION
Error message appear when moving into .git directory. This PR fix this problem.
# Steps to Reproduce

``` bash
t % cd /usr/local/.git
fatal: This operation must be run in a work tree
```
