### PR TITLE
added support for faster tracked only git dirty checking

### DIFF
--- a/prompt_lean_setup
+++ b/prompt_lean_setup
@@ -46,10 +46,9 @@ prompt_lean_git_dirty() {
     # check if we're in a git repo
     command git rev-parse --is-inside-work-tree &>/dev/null || return
     # check if it's dirty
-    local umode="-uno" #|| local umode="-unormal"
-    command test -n "$(git status --porcelain --ignore-submodules ${umode} 2>/dev/null | head -100)"
+    git diff-files --no-ext-diff --quiet || git diff-index --no-ext-diff --quiet --cached HEAD
 
-    (($? == 0)) && echo ' +'
+    (($? != 0)) && echo ' +'
 }
 
 # displays the exec time of the last command if set threshold was exceeded


### PR DESCRIPTION
I created a fork of lean (called 'mean') that consists primarily of cosmetic changes. I've noticed that the prompt has been lagging significantly on some of my larger git projects, and in some cases producing a delay of 3-5 seconds or more. This can force the prompt to become almost unusable on these larger projects.

The source of this delay is the use of ```git status --porcelain ...``` to check if a directory is dirty. To remedy this issue for people dealing with large git projects frequently, I've added an option to use a faster git dirty checking method. The downside to using this faster method is that it only works against tracked files and will only report the git directory as dirty if a tracked file has been changed. It will not report a git project as dirty if it only has new untracked files.

I've added this dirty checking method behind a configuration variable ```PROMPT_LEAN_GIT_DIRTY_CHECK``` that defaults to "normal". The faster git dirty checking functionality will only kick in, if and only if this variable is set to "fast".

You can find relevant benchmark results here: https://gist.github.com/sindresorhus/3898739