### PR TITLE
add support to python venv

### DIFF
--- a/prompt_lean_setup
+++ b/prompt_lean_setup
@@ -7,6 +7,7 @@
 
 PROMPT_LEAN_TMUX=${PROMPT_LEAN_TMUX-"t "}
 PROMPT_LEAN_PATH_PERCENT=${PROMPT_LEAN_PATH_PERCENT-60}
+PROMPT_PYTHON_VENV=${PROMPT_PYTHON_VENV-CONDA_PREFIX}
 
 prompt_lean_help() {
   cat <<'EOF'
@@ -84,6 +85,7 @@ prompt_lean_precmd() {
 
     local jobs
     local prompt_lean_jobs
+
     unset jobs
     for a (${(k)jobstates}) {
         j=$jobstates[$a];i="${${(@s,:,)j}[2]}"
@@ -93,7 +95,14 @@ prompt_lean_precmd() {
     prompt_lean_jobs=""
     [[ -n $jobs ]] && prompt_lean_jobs="%F{242}["${(j:,:)jobs}"] "
 
-    PROMPT="$prompt_lean_jobs%F{yellow}$prompt_lean_tmux%(?.%F{blue}.%B%F{red})%#%f%b "
+    # prepend python virtualenv
+    local prompt_lean_virtualenv
+    prompt_lean_virtualenv=${(P)PROMPT_PYTHON_VENV} #expand given variable name
+    if [[ ! -z $prompt_lean_virtualenv ]]; then
+         prompt_lean_virtualenv="($(basename $prompt_lean_virtualenv)) "
+    fi
+
+    PROMPT="$prompt_lean_jobs%F{yellow}${prompt_lean_virtualenv}${prompt_lean_tmux}%(?.%F{blue}.%B%F{red})%#%f%b "
     RPROMPT="%F{yellow}`prompt_lean_cmd_exec_time`%f%F{blue}`prompt_lean_pwd`%F{242}$vcs_info_msg_0_`prompt_lean_git_dirty`$prompt_lean_host%f"
 
     unset cmd_timestamp # reset value since `preexec` isn't always triggered


### PR DESCRIPTION
add support to PROMPT_PYTHON_VENV where one can set the name of a variable that contains the name of current virtualenv. Defaults to CONDA_PREFIX

shows as 

      (venv-name) %

