### PR TITLE
add support for LEAN_LEFT, LEAN_RIGHT as function names

### DIFF
--- a/prompt_lean_setup
+++ b/prompt_lean_setup
@@ -93,8 +93,8 @@ prompt_lean_precmd() {
     prompt_lean_jobs=""
     [[ -n $jobs ]] && prompt_lean_jobs="%F{242}["${(j:,:)jobs}"] "
 
-    PROMPT="$prompt_lean_jobs%F{yellow}$prompt_lean_tmux%(?.%F{blue}.%B%F{red})%#%f%b "
-    RPROMPT="%F{yellow}`prompt_lean_cmd_exec_time`%f%F{blue}`prompt_lean_pwd`%F{242}$vcs_info_msg_0_`prompt_lean_git_dirty`$prompt_lean_host%f"
+    PROMPT="$prompt_lean_jobs%F{yellow}${prompt_lean_tmux}`$LEAN_LEFT`%(?.%F{blue}.%B%F{red})%#%f%b "
+    RPROMPT="%F{yellow}`prompt_lean_cmd_exec_time`%f%F{blue}`prompt_lean_pwd`%F{242}$vcs_info_msg_0_`prompt_lean_git_dirty`$prompt_lean_host%f`$LEAN_RIGHT`"
 
     unset cmd_timestamp # reset value since `preexec` isn't always triggered
 }

--- a/prompt_lean_setup
+++ b/prompt_lean_setup
@@ -93,8 +93,8 @@ prompt_lean_precmd() {
     prompt_lean_jobs=""
     [[ -n $jobs ]] && prompt_lean_jobs="%F{242}["${(j:,:)jobs}"] "
 
-    PROMPT="$prompt_lean_jobs%F{yellow}${prompt_lean_tmux}`$LEAN_LEFT`%(?.%F{blue}.%B%F{red})%#%f%b "
-    RPROMPT="%F{yellow}`prompt_lean_cmd_exec_time`%f%F{blue}`prompt_lean_pwd`%F{242}$vcs_info_msg_0_`prompt_lean_git_dirty`$prompt_lean_host%f`$LEAN_RIGHT`"
+    PROMPT="$prompt_lean_jobs%F{yellow}${prompt_lean_tmux}%f`$LEAN_LEFT`%f%(?.%F{blue}.%B%F{red})%#%f%b "
+    RPROMPT="%F{yellow}`prompt_lean_cmd_exec_time`%f%F{blue}`prompt_lean_pwd`%F{242}$vcs_info_msg_0_`prompt_lean_git_dirty`$prompt_lean_host%f`$LEAN_RIGHT`%f"
 
     unset cmd_timestamp # reset value since `preexec` isn't always triggered
 }


### PR DESCRIPTION
feel free not to merge this if this feels too much bloat 

usage example:

<img width="682" alt="screen shot 2016-12-23 at 18 55 40" src="https://cloud.githubusercontent.com/assets/380791/21459866/98fec180-c942-11e6-830d-de33cf40d820.png">

example for python venv (anaconda)

```sh
LEAN_LEFT=lean_left
lean_left() {
  if [[ ! -z $CONDA_PREFIX ]]; then
       echo "($(basename $CONDA_PREFIX)) "
  fi
}
```
