### PR TITLE
Return success from prompt_lean_setup

### DIFF
--- a/prompt_lean_setup
+++ b/prompt_lean_setup
@@ -132,6 +132,8 @@ prompt_lean_setup() {
 
     [[ "$SSH_CONNECTION" != '' ]] && prompt_lean_host=" %F{yellow}%m%f"
     [[ "$TMUX" != '' ]] && prompt_lean_tmux=$PROMPT_LEAN_TMUX
+
+    return 0
 }
 
 prompt_lean_setup "$@"


### PR DESCRIPTION
When $TMUX is unset the exit status becomes non-zero, which certain plugin managers (zplug) flag as a failure loading the plugin.