### PR TITLE
Add default title

### DIFF
--- a/prompt_lean_setup
+++ b/prompt_lean_setup
@@ -108,6 +108,9 @@ prompt_lean_precmd() {
     RPROMPT="%F{yellow}`prompt_lean_cmd_exec_time`%f%F{blue}`prompt_lean_pwd`%F{242}$vcs_info_str`prompt_lean_git_dirty`$prompt_lean_host%f"
 
     unset cmd_timestamp # reset value since `preexec` isn't always triggered
+
+    # shows the current dir in the title when there are no active processes
+    print -Pn "\e]0;$PWD:t\a"
 }
 
 function zle-keymap-select {


### PR DESCRIPTION
Show the current dir in the title when there are no active processes.

This change fixes displaying last command in the title.