### PR TITLE
Allow color override

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ and clean
 * For a configurable insertmode indicator, set the `PROMPT_LEAN_VIMODE` and `PROMPT_LEAN_VIMODE_FORMAT`
 variables. 
   `PROMPT_LEAN_VIMODE_FORMAT` defaults to `"%F{red}[NORMAL]%f"`
+* Configurable colors to match your preferred scheme, by setting
+  `PROMPT_LEAN_COLOR1` and `PROMPT_LEAN_COLOR2`
 
 When lean starts, only 2 characters show on the screen '%' on the left and '~'
 on the right. All other info is omitted (like the user and system you are on),

--- a/prompt_lean_setup
+++ b/prompt_lean_setup
@@ -8,8 +8,8 @@
 #
 # MIT License
 
-COLOR1="241"
-COLOR2="140"
+COLOR1=${PROMPT_LEAN_COLOR1-"241"}
+COLOR2=${PROMPT_LEAN_COLOR2-"140"}
 
 PROMPT_LEAN_TMUX=${PROMPT_LEAN_TMUX-"t "}
 PROMPT_LEAN_PATH_PERCENT=${PROMPT_LEAN_PATH_PERCENT-60}
@@ -28,6 +28,8 @@ Configuration:
 PROMPT_LEAN_TMUX: used to indicate being in tmux, set to "t ", by default
 PROMPT_LEAN_LEFT: executed to allow custom information in the left side
 PROMPT_LEAN_RIGHT: executed to allow custom information in the right side
+PROMPT_LEAN_COLOR1: jobs and VCS info indicator color
+PROMPT_LEAN_COLOR2: prompt character and directory color
 PROMPT_LEAN_VIMODE: used to determine wither or not to display indicator
 PROMPT_LEAN_VIMODE_FORMAT: Defaults to "%F{red}[NORMAL]%f"
 


### PR DESCRIPTION
Let's colors be set from `/.zshrc`.

For Solarized this seem to work good:

```
PROMPT_LEAN_COLOR1="242"
PROMPT_LEAN_COLOR2="blue"

if [ -f $ZPLUG_HOME/init.zsh ]; then
  source $ZPLUG_HOME/init.zsh

  zplug "miekg/lean"
```