### PR TITLE
Possible fix for broken VCS indicator

### DIFF
--- a/prompt_lean_setup
+++ b/prompt_lean_setup
@@ -109,6 +109,7 @@ prompt_lean_precmd() {
 
     prompt_lean_vimode="${${KEYMAP/vicmd/$lean_vimode_indicator}/(main|viins)/}"
 
+    setopt promptsubst
     local vcs_info_str='$vcs_info_msg_0_' # avoid https://github.com/njhartwell/pw3nage
     PROMPT="$prompt_lean_jobs%F{yellow}${prompt_lean_tmux}%f`$PROMPT_LEAN_LEFT`%f%(?.%F{"$COLOR2"}.%B%F{red})%#%f%b "
     RPROMPT="%F{yellow}`prompt_lean_cmd_exec_time`%f$prompt_lean_vimode%F{"$COLOR2"}`prompt_lean_pwd`%F{"$COLOR1"}$vcs_info_str`prompt_lean_git_dirty`$prompt_lean_host%f`$PROMPT_LEAN_RIGHT`%f"


### PR DESCRIPTION
I'm not sure if this works for everyone but tested it on my machine and it behaves as expected. Without this change all I can see is `~/src/lean$vcs_info_msg_0_`