### PR TITLE
updated README.md with installation instructions for prezto

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,32 +64,17 @@ Note you must have the option PROMPT_SUBST set, see zshoptions(1).
 
 prezto
 ---
-If you use [prezto](https://github.com/sorin-ionescu/prezto)
-you should do the following (unless lean is included):
+If you use [prezto](https://github.com/sorin-ionescu/prezto) you should do the following:
 ```
-cd ~/.zprezto/
-git submodule add https://github.com/miekg/lean.git modules/prompt/external/lean
-git submodule update --init --recursive
-cd modules/prompt/functions
-ln -s ../external/lean/prompt_lean_setup
+cd ~/.zprezto/ \
+&& git submodule add https://github.com/miekg/lean.git modules/prompt/external/lean 2>/dev/null \
+&& git submodule update --init --recursive \
+&& cd modules/prompt/functions \
+&& ln -s ../external/lean/prompt_lean_setup
 ```
 Then in `~/.zpreztorc`:
 ```
 zstyle ':prezto:module:prompt' theme 'lean'
 ```
-You can customize prompt colors in `~/.zshenv`:
-```
-export PROMPT_LEAN_COLOR1='blue'
-export PROMPT_LEAN_COLOR2='green'
-```
-You can customize `PROMPT_LEAN_LEFT` and `PROMPT_LEAN_RIGHT` in `~/.zshrc`:
-```
-# for instance here goes prezto python module support
-function lean-left {
-  if (( $+functions[python-info] )); then
-      python-info
-      echo $python_info[virtualenv]
-  fi
-}
-export PROMPT_LEAN_LEFT='lean-left'
-```
+`PROMPT_LEAN_LEFT` and `PROMPT_LEAN_RIGHT` should be customized in `~/.zshrc`.
+The rest variables should be customized in `~/.zshenv`. 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ character and the start of the command line. **NOTE** This
 Installation
 ===========
 
+zgen
+---
 If you use [zgen](https://github.com/tarjoilija/zgen) you can add the following
 to your `~/.zshrc`:
 
@@ -59,3 +61,35 @@ zgen load miekg/lean
 and force reload with `zgen reset && source~/.zshrc`.
 
 Note you must have the option PROMPT_SUBST set, see zshoptions(1).
+
+prezto
+---
+If you use [prezto](https://github.com/sorin-ionescu/prezto)
+you should do the following (unless lean is included):
+```
+cd ~/.zprezto/
+git submodule add https://github.com/miekg/lean.git modules/prompt/external/lean
+git submodule update --init --recursive
+cd modules/prompt/functions
+ln -s ../external/lean/prompt_lean_setup
+```
+Then in `~/.zpreztorc`:
+```
+zstyle ':prezto:module:prompt' theme 'lean'
+```
+You can customize prompt colors in `~/.zshenv`:
+```
+export PROMPT_LEAN_COLOR1='blue'
+export PROMPT_LEAN_COLOR2='green'
+```
+You can customize `PROMPT_LEAN_LEFT` and `PROMPT_LEAN_RIGHT` in `~/.zshrc`:
+```
+# for instance here goes prezto python module support
+function lean-left {
+  if (( $+functions[python-info] )); then
+      python-info
+      echo $python_info[virtualenv]
+  fi
+}
+export PROMPT_LEAN_LEFT='lean-left'
+```

--- a/prompt_lean_setup
+++ b/prompt_lean_setup
@@ -105,11 +105,6 @@ prompt_lean_precmd() {
     prompt_lean_jobs=""
     [[ -n $jobs ]] && prompt_lean_jobs="%F{"$COLOR1"}["${(j:,:)jobs}"] "
 
-    # optional support for python module from zprezto
-    if (( $+functions[python-info] )); then
-        python-info
-    fi
-
     local lean_vimode_default="%F{red}[NORMAL]%f"
     #If LEAN_VIMODE is set, set lean_vimode_indicator to either PROMPT_LEAN_VIMOD_FORMAT or a default value
     local lean_vimode_indicator="${PROMPT_LEAN_VIMODE:+${PROMPT_LEAN_VIMODE_FORMAT:-${lean_vimode_default}}}"
@@ -118,7 +113,7 @@ prompt_lean_precmd() {
 
     setopt promptsubst
     local vcs_info_str='$vcs_info_msg_0_' # avoid https://github.com/njhartwell/pw3nage
-    PROMPT="$prompt_lean_jobs%F{yellow}${prompt_lean_tmux}%f${python_info[virtualenv]}`$PROMPT_LEAN_LEFT`%f%(?.%F{"$COLOR2"}.%B%F{red})%#%f%b "
+    PROMPT="$prompt_lean_jobs%F{yellow}${prompt_lean_tmux}%f`$PROMPT_LEAN_LEFT`%f%(?.%F{"$COLOR2"}.%B%F{red})%#%f%b "
     RPROMPT="%F{yellow}`prompt_lean_cmd_exec_time`%f$prompt_lean_vimode%F{"$COLOR2"}`prompt_lean_pwd`%F{"$COLOR1"}$vcs_info_str`prompt_lean_git_dirty`$prompt_lean_host%f`$PROMPT_LEAN_RIGHT`%f"
 
     unset cmd_timestamp # reset value since `preexec` isn't always triggered

--- a/prompt_lean_setup
+++ b/prompt_lean_setup
@@ -105,6 +105,11 @@ prompt_lean_precmd() {
     prompt_lean_jobs=""
     [[ -n $jobs ]] && prompt_lean_jobs="%F{"$COLOR1"}["${(j:,:)jobs}"] "
 
+    # optional support for python module from zprezto
+    if (( $+functions[python-info] )); then
+        python-info
+    fi
+
     local lean_vimode_default="%F{red}[NORMAL]%f"
     #If LEAN_VIMODE is set, set lean_vimode_indicator to either PROMPT_LEAN_VIMOD_FORMAT or a default value
     local lean_vimode_indicator="${PROMPT_LEAN_VIMODE:+${PROMPT_LEAN_VIMODE_FORMAT:-${lean_vimode_default}}}"
@@ -113,7 +118,7 @@ prompt_lean_precmd() {
 
     setopt promptsubst
     local vcs_info_str='$vcs_info_msg_0_' # avoid https://github.com/njhartwell/pw3nage
-    PROMPT="$prompt_lean_jobs%F{yellow}${prompt_lean_tmux}%f`$PROMPT_LEAN_LEFT`%f%(?.%F{"$COLOR2"}.%B%F{red})%#%f%b "
+    PROMPT="$prompt_lean_jobs%F{yellow}${prompt_lean_tmux}%f${python_info[virtualenv]}`$PROMPT_LEAN_LEFT`%f%(?.%F{"$COLOR2"}.%B%F{red})%#%f%b "
     RPROMPT="%F{yellow}`prompt_lean_cmd_exec_time`%f$prompt_lean_vimode%F{"$COLOR2"}`prompt_lean_pwd`%F{"$COLOR1"}$vcs_info_str`prompt_lean_git_dirty`$prompt_lean_host%f`$PROMPT_LEAN_RIGHT`%f"
 
     unset cmd_timestamp # reset value since `preexec` isn't always triggered


### PR DESCRIPTION
@miekg, i really love lean prompt and want it to be included in [prezto framework](https://github.com/sorin-ionescu/prezto). so:

1. i ask for your approval to include lean into prezto. it would be included via git submodule and i already have appropriate patches for prezto
2. before being included into prezto i want to enhance lean a bit so that it will fit better. for my daily needs i use Python a lot so here's the **optional** Python module support

here's the demo of what it would look like with my patch:
```
# assuming prezto setting zstyle ':prezto:module:python:info:virtualenv' format '(py %v) '
# right side of prompt is omitted for clarity

% tmux new -s lean
t % workon someenv
t (py someenv) % vim
[1]  + 907 suspended  vim
[1+] t (py someenv) % 

% workon someenv
(py someenv) %
```