### PR TITLE
Add sp to the prompt_opts array

### DIFF
--- a/prompt_lean_setup
+++ b/prompt_lean_setup
@@ -125,7 +125,7 @@ function zle-keymap-select {
 }
 
 prompt_lean_setup() {
-    prompt_opts=(cr subst percent)
+    prompt_opts=(cr percent sp subst)
 
     zmodload zsh/datetime
     autoload -Uz add-zsh-hook


### PR DESCRIPTION
so fix `nopromptsp` being set in zsh 5.4, which hides the last line of outputs without a LF character at the end, like

    echo -n "bla"

With zsh starting at version 5.4, when using the `prompt_opts` array, `nopromptsp` will be set unless the array contains a `sp`. This was introduced in zsh at https://github.com/zsh-users/zsh/commit/43e55a9bcd2c90124a751f2597d2f33cb6e3c042#diff-bb10d67e7a8561b66a53a805f3c77a40R233

Fixes #31