### PR TITLE
Term title: cleanup command and show tty

### DIFF
--- a/prompt_lean_setup
+++ b/prompt_lean_setup
@@ -73,9 +73,9 @@ prompt_lean_cmd_exec_time() {
 prompt_lean_preexec() {
     cmd_timestamp=$EPOCHSECONDS
 
-    # shows the current dir and executed command in the title when a process is active
+    # shows the current tty and dir and executed command in the title when a process is active
     print -Pn "\e]0;"
-    echo -nE "$PWD:t: $2"
+    print -Pn "%l %1d: $1"
     print -Pn "\a"
 }
 


### PR DESCRIPTION
For $reasons I wanted to see my tty so this adds that. It also
uses $1 in preexec which is way cleaner than the fully expanded $2
we've been using, also drop $PWD and use print -P to allow the use of
prompt verbs.