### PR TITLE
Term title: unset under Emacs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ variables.
   `PROMPT_LEAN_VIMODE_FORMAT` defaults to `"%F{red}[NORMAL]%f"`
 * Configurable colors to match your preferred scheme, by setting
   `PROMPT_LEAN_COLOR1` and `PROMPT_LEAN_COLOR2`
+* Use `PROMPT_LEAN_NOTITLE` to customize when the title should not be display. Useful for terminals can not show title properly, for example terminals under Emacs (already considered by default). Write your own conditions for this variable and make sure it is 1 when you don't want title.
 
 When lean starts, only 2 characters show on the screen '%' on the left and '~'
 on the right. All other info is omitted (like the user and system you are on),

--- a/prompt_lean_setup
+++ b/prompt_lean_setup
@@ -72,13 +72,19 @@ prompt_lean_cmd_exec_time() {
     (($elapsed > ${PROMPT_LEAN_CMD_MAX_EXEC_TIME:=5})) && prompt_lean_human_time $elapsed
 }
 
-prompt_lean_preexec() {
-    cmd_timestamp=$EPOCHSECONDS
+prompt_lean_set_title() {
+    # emacs terminal does not support settings the title
+    (( ${+EMACS} )) && return
 
     # shows the current tty and dir and executed command in the title when a process is active
     print -Pn "\e]0;"
     print -Pn "%l %1d: $1"
     print -Pn "\a"
+}
+
+prompt_lean_preexec() {
+    cmd_timestamp=$EPOCHSECONDS
+    prompt_lean_set_title
 }
 
 prompt_lean_pwd() {

--- a/prompt_lean_setup
+++ b/prompt_lean_setup
@@ -34,8 +34,8 @@ PROMPT_LEAN_COLOR2: prompt character and directory color
 PROMPT_LEAN_VIMODE: used to determine wether or not to display indicator
 PROMPT_LEAN_VIMODE_FORMAT: Defaults to "%F{red}[NORMAL]%f"
 PROMPT_LEAN_NOTITLE: used to determine wether or not to set title, set to 0
- by defualt, it will be 1 under Emacs. Set it to your own indicator, make
- it to be 1 when you don't want title.
+ by defualt. Set it to your own condition, make it to be 1 when you don't
+ want title.
 
 You can invoke it thus:
 
@@ -85,7 +85,7 @@ prompt_lean_set_title() {
 
 prompt_lean_preexec() {
     cmd_timestamp=$EPOCHSECONDS
-    local lean_no_title=$((${+EMACS} || $PROMPT_LEAN_NOTITLE))
+    local lean_no_title=$PROMPT_LEAN_NOTITLE
     (($lean_no_title != 1)) && prompt_lean_set_title
     unset lean_no_title
 }

--- a/prompt_lean_setup
+++ b/prompt_lean_setup
@@ -13,6 +13,7 @@ COLOR2=${PROMPT_LEAN_COLOR2-"140"}
 
 PROMPT_LEAN_TMUX=${PROMPT_LEAN_TMUX-"t "}
 PROMPT_LEAN_PATH_PERCENT=${PROMPT_LEAN_PATH_PERCENT-60}
+PROMPT_LEAN_NOTITLE=${PROMPT_LEAN_NOTITLE-0}
 
 prompt_lean_help() {
   cat <<'EOF'
@@ -30,8 +31,11 @@ PROMPT_LEAN_LEFT: executed to allow custom information in the left side
 PROMPT_LEAN_RIGHT: executed to allow custom information in the right side
 PROMPT_LEAN_COLOR1: jobs and VCS info indicator color
 PROMPT_LEAN_COLOR2: prompt character and directory color
-PROMPT_LEAN_VIMODE: used to determine wither or not to display indicator
+PROMPT_LEAN_VIMODE: used to determine wether or not to display indicator
 PROMPT_LEAN_VIMODE_FORMAT: Defaults to "%F{red}[NORMAL]%f"
+PROMPT_LEAN_NOTITLE: used to determine wether or not to set title, set to 0
+ by defualt, it will be 1 under Emacs. Set it to your own indicator, make
+ it to be 1 when you don't want title.
 
 You can invoke it thus:
 
@@ -73,9 +77,6 @@ prompt_lean_cmd_exec_time() {
 }
 
 prompt_lean_set_title() {
-    # emacs terminal does not support settings the title
-    (( ${+EMACS} )) && return
-
     # shows the current tty and dir and executed command in the title when a process is active
     print -Pn "\e]0;"
     print -Pn "%l %1d: $1"
@@ -84,7 +85,9 @@ prompt_lean_set_title() {
 
 prompt_lean_preexec() {
     cmd_timestamp=$EPOCHSECONDS
-    prompt_lean_set_title
+    local lean_no_title=$((${+EMACS} || $PROMPT_LEAN_NOTITLE))
+    (($lean_no_title != 1)) && prompt_lean_set_title
+    unset lean_no_title
 }
 
 prompt_lean_pwd() {


### PR DESCRIPTION
I referenced pure theme for how to deal with title under Emacs, and create a function for setting title. Related issue #34.