### PR TITLE
Term title: prevent expansion of command

### DIFF
--- a/prompt_lean_setup
+++ b/prompt_lean_setup
@@ -77,7 +77,8 @@ prompt_lean_preexec() {
 
     # shows the current tty and dir and executed command in the title when a process is active
     print -Pn "\e]0;"
-    print -Pn "%l %1d: $1"
+    print -Pn "%l %1d"
+    print -n ": $1"
     print -Pn "\a"
 }
 


### PR DESCRIPTION
This disables prompt expansion for printing executed command in the title.

When executed command contains some prompt escapes `zshmisc(1)` they are being
evaluated and printed to the terminal.

Example:
```
% date '+%F%N'                                                                 ~
]0;pts/1 hitori: date '+prompt_lean_preexec'2018-01-04413295684
```