### PR TITLE
Added shrink abbreviation method for cwd (e.g. ~/p/s/app)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ plugin (or prior to sourcing `zgen`, etc.).
 and clean
 * Shows background jobs (in the left prompt)
 * Show (dirty) git repos
-* Shortens path if needed (longer then 70% of your screen)
+* Shortens path if needed (longer then 70% of your screen). Two methods are provided:
+'truncate' and 'shrink' (fish-style working directory). Set `PROMPT_LEAN_ABBR_METHOD` 
+to choose the one you like the most (default is 'truncate').
 * Uses `PROMPT_LEAN_LEFT` and `PROMPT_LEAN_RIGHT` to allow customization of the left
   and/or right side of the prompt.
 * For a configurable insertmode indicator, set the `PROMPT_LEAN_VIMODE` and `PROMPT_LEAN_VIMODE_FORMAT`

--- a/prompt_lean_setup
+++ b/prompt_lean_setup
@@ -40,6 +40,9 @@ PROMPT_LEAN_VIMODE_FORMAT: Defaults to "%F{red}[NORMAL]%f"
 PROMPT_LEAN_NOTITLE: used to determine wether or not to set title, set to 0
  by default. Set it to your own condition, make it to be 1 when you don't
  want title.
+PROMPT_LEAN_ABBR_METHOD: used to indicate the abbreviation method for directory
+paths. Set it either to 'truncate' (default) or 'shrink' (fish-style 
+working directory)
 
 You can invoke it thus:
 

--- a/prompt_lean_setup
+++ b/prompt_lean_setup
@@ -16,6 +16,7 @@ COLOR3=${PROMPT_LEAN_COLOR3-"150"}
 PROMPT_LEAN_TMUX=${PROMPT_LEAN_TMUX-"t "}
 PROMPT_LEAN_PATH_PERCENT=${PROMPT_LEAN_PATH_PERCENT-60}
 PROMPT_LEAN_NOTITLE=${PROMPT_LEAN_NOTITLE-0}
+PROMPT_LEAN_ABBR_METHOD=${PROMPT_LEAN_ABBR_METHOD-"truncate"}
 
 prompt_lean_help() {
   cat <<'EOF'
@@ -97,10 +98,33 @@ prompt_lean_preexec() {
 prompt_lean_pwd() {
     local lean_path="`print -Pn '%~'`"
     if (($#lean_path / $COLUMNS.0 * 100 > ${PROMPT_LEAN_PATH_PERCENT:=60})); then
-        print -Pn '...%2/'
+		case "$PROMPT_LEAN_ABBR_METHOD" in
+			"truncate") prompt_lean_abbr_truncate;;
+			"shrink")   prompt_lean_abbr_shrink;;
+		esac
         return
     fi
     print "$lean_path"
+}
+
+prompt_lean_abbr_truncate() {
+	print -Pn '...%2/'
+}
+
+prompt_lean_abbr_shrink() {
+	setopt local_options extendedglob histsubstpattern
+
+	local lean_path=$(print -Pn '%~')
+	local maxlen=$((PROMPT_LEAN_PATH_PERCENT * COLUMNS / 100))
+	local prevlen=0
+
+	# iterate until target length achieved or no more abbreviation possible
+	while (($#lean_path > maxlen && $#lean_path != prevlen)); do
+		prevlen=$#lean_path
+		lean_path=${lean_path:s_(#b)([^/])([^/])##/_$match[1]/_}
+	done
+
+	echo $lean_path
 }
 
 prompt_lean_precmd() {

--- a/prompt_lean_test.zsh
+++ b/prompt_lean_test.zsh
@@ -82,3 +82,21 @@ prompt_lean_preexec
 expect='%F{'$COLOR3'}1s %f%F{'$COLOR2'}/tmp%F{'$COLOR1'}$vcs_info_msg_0_%f%f'
 comphex "time" $RPROMPT $expect
 )
+
+( LONGDIR="/tmp/app/src/main/java/com/example"
+mkdir -p $LONGDIR && cd $LONGDIR
+abbr_dir=$(COLUMNS=100 PROMPT_LEAN_PATH_PERCENT=34 prompt_lean_abbr_shrink)
+comphex "abbr-shrink-unchanged" $abbr_dir $LONGDIR
+)
+
+( LONGDIR="/tmp/app/src/main/java/com/example"
+mkdir -p $LONGDIR && cd $LONGDIR
+abbr_dir=$(COLUMNS=100 PROMPT_LEAN_PATH_PERCENT=33 prompt_lean_abbr_shrink)
+comphex "abbr-shrink-1" $abbr_dir "/t/app/src/main/java/com/example"
+)
+
+( LONGDIR="/tmp/app/src/main/java/com/example"
+mkdir -p $LONGDIR && cd $LONGDIR
+abbr_dir=$(COLUMNS=100 PROMPT_LEAN_PATH_PERCENT=5 prompt_lean_abbr_shrink)
+comphex "abbr-shrink-full" $abbr_dir "/t/a/s/m/j/c/example"
+)


### PR DESCRIPTION
An alternative option for shortening the current working directory displayed in the right prompt (e.g. ~/projects/sample/app to ~/p/s/app).

The original shortening method (e.g. ~/projects/sample/app to .../sample/app) is set as default. Switching to the new style is done by setting:

```
export PROMPT_LEAN_ABBR_METHOD="shrink"
```
Note that the algorithm **is not greedy** in the sense that each ancestor directory in the hierarchy (from top to bottom) gets shrinked into its initial letter as long as the resulting name doesn't fulfill the PROMPT_LEAN_PATH_PERCENT setting. Thus:

- ~/projects/sample/app remains the same if 30 positions are available.
- ~/projects/sample/app turns into ~/p/sample/app if 20 positions are available.
- ~/projects/sample/app turns into ~/p/s/app if 10 positions are available.

The last component of the path is never abbreviated regardless of the space available.

This behavior is different from other implementations such as [the shrink-path plugin for oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh/tree/master/plugins/shrink-path) that doesn't consider any maximum length.

The approach is similar to the conversions performed by the  [Spring logging system](https://logback.qos.ch/manual/layouts.html#conversionWord).



