### PR TITLE
fix background

### DIFF
--- a/prompt_lean_setup
+++ b/prompt_lean_setup
@@ -153,7 +153,7 @@ prompt_lean_precmd() {
 
     setopt promptsubst
     local vcs_info_str='$vcs_info_msg_0_' # avoid https://github.com/njhartwell/pw3nage
-    PROMPT="$prompt_lean_jobs%F{"$COLOR3"}${prompt_lean_tmux}%f`$PROMPT_LEAN_LEFT`%f%(?.%F{"$COLOR2"}.%B%F{203}%K{234})%#%f%k%b "
+    PROMPT="$prompt_lean_jobs%F{"$COLOR3"}${prompt_lean_tmux}%f`$PROMPT_LEAN_LEFT`%f%(?.%F{"$COLOR2"}.%B%F{203})%#%f%k%b "
     RPROMPT="%F{"$COLOR3"}`prompt_lean_cmd_exec_time`%f$prompt_lean_vimode%F{"$COLOR2"}`prompt_lean_pwd`%F{"$COLOR1"}$vcs_info_str`prompt_lean_git_dirty`$prompt_lean_host%f`$PROMPT_LEAN_RIGHT`%f"
 
     unset cmd_timestamp # reset value since `preexec` isn't always triggered

--- a/prompt_lean_test.zsh
+++ b/prompt_lean_test.zsh
@@ -31,7 +31,7 @@ source prompt_lean_setup
 (
 prompt_lean_precmd
 prompt_lean_preexec
-expect='%F{'$COLOR3'}%f%f%(?.%F{'$COLOR2'}.%B%F{red})%#%f%b '
+expect='%F{'$COLOR3'}%f%f%(?.%F{'$COLOR2'}.%B%F{203})%#%f%k%b '
 comphex "prompt" $PROMPT $expect
 )
 
@@ -48,7 +48,7 @@ PROMPT_LEAN_LEFT=left
 
 prompt_lean_precmd
 prompt_lean_preexec
-expect='%F{'$COLOR3'}%fleft%f%(?.%F{'$COLOR2'}.%B%F{red})%#%f%b '
+expect='%F{'$COLOR3'}%fleft%f%(?.%F{'$COLOR2'}.%B%F{203})%#%f%k%b '
 comphex "lean_left" $PROMPT $expect
 )
 
@@ -69,7 +69,7 @@ source prompt_lean_setup # TMUX is only evaluated in setup
 
 prompt_lean_precmd
 prompt_lean_preexec
-expect='%F{'$COLOR3'}t%f%f%(?.%F{'$COLOR2'}.%B%F{red})%#%f%b '
+expect='%F{'$COLOR3'}t%f%f%(?.%F{'$COLOR2'}.%B%F{203})%#%f%k%b '
 comphex "tmux" $PROMPT $expect
 )
 


### PR DESCRIPTION
Fix background when command failed and we draw a red %, the background
was set to black. Don't do this; use the default terminal background.