### PR TITLE
fix: omit vcs info errors

### DIFF
--- a/prompt_lean_setup
+++ b/prompt_lean_setup
@@ -136,7 +136,7 @@ prompt_lean_abbr_shrink() {
 }
 
 prompt_lean_precmd() {
-    [[ $PROMPT_LEAN_VCS == 1 ]] && vcs_info
+    [[ $PROMPT_LEAN_VCS == 1 ]] && vcs_info 2>/dev/null
     rehash
 
     local jobs


### PR DESCRIPTION
There's cases where `vcs_info` outputs `git` errors, which should be unwanted for a prompt. I noticed it when working with `git worktree` and using a `bare` repo as the base. 

Issue is reproducible with:

```sh
% mkdir lean
mkdir: created directory 'lean'
% cd lean                                                                                                                                                                                      ~/code
% git clone --bare git@github.com:miekg/lean.git .git
Cloning into bare repository '.git'...
remote: Enumerating objects: 219, done.
remote: Counting objects: 100% (19/19), done.
remote: Compressing objects: 100% (13/13), done.
remote: Total 219 (delta 7), reused 12 (delta 4), pack-reused 200
Receiving objects: 100% (219/219), 154.72 KiB | 937.00 KiB/s, done.
Resolving deltas: 100% (115/115), done.
fatal: this operation must be run in a work tree
% ll
fatal: this operation must be run in a work tree
```
Sending the `vcs_info` errors to `/dev/null` swallows these errors.